### PR TITLE
feat: persist formvalues, partly mand. locations

### DIFF
--- a/controllers/IndexController.js
+++ b/controllers/IndexController.js
@@ -76,8 +76,6 @@ module.exports.landingpage = async (req, res) => {
             .limit(2)
             .populate("location")
           if (event) {
-
-
             events.push(...event)
           }
         }
@@ -98,7 +96,7 @@ module.exports.landingpage = async (req, res) => {
       companyStories: companyStoriesRes.length !== 0 ? companyStoriesRes : nonComanyStoriesRes.splice(nonComanyStoriesRes.length, nonComanyStoriesRes.length + 3),
       nonComanyStories: nonComanyStoriesRes.splice(0, 3),
       partners: partnersRes,
-      locations: locationsRes.filter(l => events.map(e => e.location._id).includes(l._id)),
+      locations: locationsRes,
       contact_user,
       courses: coursesRes
     })
@@ -108,8 +106,10 @@ module.exports.landingpage = async (req, res) => {
 }
 module.exports.contactLocations = async (req, res) => {
   const locations = await Location.find({})
+  const contact = req.body
   res.render('contactLocations', {
-    locations
+    locations,
+    contact
   })
 };
 module.exports.contact = async (req, res, next) => {
@@ -126,7 +126,7 @@ module.exports.contact = async (req, res, next) => {
       next()
       return;
     }
-    if (!email || !name || !body || !phone || !locations || !TermsofService) {
+    if (!email || !name || !body || !phone || !TermsofService) {
       req.flash('danger', 'Please fill out all form fields')
       res.redirect(req.headers.referer)
       next()
@@ -168,10 +168,7 @@ module.exports.contact = async (req, res, next) => {
       <td>Content: </td>
       <td>${req.body.body}</td>
     </tr>
-    <tr>
-      <td>Locations: </td>
-      <td>${location.name}</td>
-    </tr>
+    ${req.body.locations && `<tr> <td>Locations: </td> <td>${location.name}</td> </tr>`}
     </table>
   `
     await contact.save()

--- a/views/mixins/contactform.pug
+++ b/views/mixins/contactform.pug
@@ -3,7 +3,7 @@ mixin contactform
     .row
       .col-md-6.mb-3
         label.sr-only(for='name')=__("Name")
-        input#name.form-control(name="name" type='text', placeholder='Name', value='', required)
+        input#name.form-control(name="name" type='text', placeholder='Name', value=contact ? contact.name : '', required)
         input#track.form-control(name="track" type="hidden" )
       .col-md-6.mb-3
         label.sr-only(for='email')=__("Email")
@@ -12,16 +12,17 @@ mixin contactform
       .col-md-12
         .form-group
           label.sr-only(for='body')=__("Message")
-          textarea.mb-3#body.form-control(name="body" placeholder=__("Please, write your message here..."), value='', required)
+          textarea.mb-3#body.form-control(name="body" placeholder=__("Please, write your message here..."), value=contact ? contact.body : '', required)
         .form-group
           label.sr-only(for='phone')=__("Phone")
           input#phone.form-control(name="phone" type='number', pattern="[0-9]", placeholder='0123456789' required)
           input#age.agefield.form-control(name="age" type='text', placeholder='25')
-        label.sr-only(for='location') Location
-        select.mb-3.custom-select.text-muted.form-control(required='', name="locations")
-          option( selected disabled value="")=__("Select your location here...")
-          each location in locations
-            option(value=(location._id))=location.name
+        if locations.length > 0
+          label.sr-only(for='location') Location
+          select.mb-3.custom-select.text-muted.form-control(required='', name="locations")
+            option( contact && selected disabled value="")=__("Select your location here...")
+            each location in locations
+              option(value=(location._id))=location.name
         p.dataPrivacyLink
           label.checkbox.TermsofService.text-muted
             =__("I have read and agree to the")


### PR DESCRIPTION
- In case frontend validation is in some way bypassed, we persist the values in the formfields. So users dont have to type them again
- locations are not filtered if they have a belonging event anymore. That could cause a empty page when clicked in the footer on a location that have no events.
- locations are not required field anymore. I dont know the marketing implications, but I would rather also send a general contact submissions without a specific location. 