### PR TITLE
fix: filter global locations object by isCampus

### DIFF
--- a/server.js
+++ b/server.js
@@ -193,7 +193,7 @@ app.use(async (req, res, next) => {
     const headerCat = await Menulocation.findOne({ name: 'header' })
 
     const [locations, settings, footerPages, headerPages] = await Promise.all([
-      Location.find({}).sort({ order: 1 }).exec(),
+      Location.find({ isCampus: false }).sort({ order: 1 }).exec(),
       Setting.findOne().exec({}),
       Page.find(Object.assign(query, { menulocations: { $in: [footerCat] } })).sort({ order: 1 }),
       Page.find(Object.assign(query, { menulocations: { $in: [headerCat] } })).sort({ order: 1 })


### PR DESCRIPTION
Removes Berlin, Muenchen, Hamburg from contact-form drop-down.