### PR TITLE
fix: redirect to settings

### DIFF
--- a/server.js
+++ b/server.js
@@ -293,7 +293,7 @@ app.use('/admin/questions', questionsAdminRoutes)
 app.use('/admin/users', usersAdminRoutes)
 app.use('/admin/redirects', redirectsAdminRoutes)
 
-app.use('/admin*', contactsAdminRoutes)
+app.use('/admin*', settingsAdminRoutes)
 app.use(redirects)
 // app.get('*', function (req, res) {
 //   res.redirect('/')


### PR DESCRIPTION
- before: admin login took forever because it redirected to `/contacts`, which loads ALL contacts
- now: simply redirect to `/settings` which is more quick