### PR TITLE
Multistep question interview improvements 3

### DIFF
--- a/assets/scripts/QuestionsDiagram.jsx
+++ b/assets/scripts/QuestionsDiagram.jsx
@@ -82,7 +82,6 @@ const colorFreeanswer = "rgb(182, 133, 1)"
 const colorAnswer = "rgb(255, 204, 1)"
 const colorError = "rgb(255,0,0)"
 const questioncolor = "rgb(0, 128, 129)"
-let availableFields = []
 function QuestionsDiagram() {
   let [loading, setloading] = useState(true)
   const emptyForm = {
@@ -105,6 +104,8 @@ function QuestionsDiagram() {
   let [answers, setanswers] = useState([])
   let [currentModelId, setmodelState] = useState("")
   let [error, seterror] = useState([])
+  let [hbFields, sethbFields] = useState([])
+  let [hbFieldsAnswers, sethbFieldsAnswers] = useState([])
   useEffect(() => {
     formRef.current = form
   }, [form])
@@ -143,7 +144,7 @@ function QuestionsDiagram() {
     }).then(res => res.json())
       .then(res => {
         if (res.payload.questions.length > 0) {
-          availableFields = res.payload.hb_fields
+          sethbFields(res.payload.hb_fields)
           setallFlows(res.payload.questions)
           setanswers(res.payload.answers)
           const initialModel = res.payload.questions[0]
@@ -230,8 +231,8 @@ function QuestionsDiagram() {
     parseAllNodesForHubspotFields()
   }
 
-  var checkDropDown = (availableFields, aI) => {
-    const subHbFields = availableFields.find(aF => aF.name === aI.options.extras.answeridentifier)
+  var checkDropDown = (aI) => {
+    const subHbFields = hbField.find(aF => aF.name === aI.options.extras.answeridentifier)
     const dropdownAnswers = aI.options.name.split(":").reverse()[0]
     const rawAnswers = dropdownAnswers.split(',').map(a => a.trim())
     const rawAnswersWithoutLabels = rawAnswers.map(a => a.replace(/\(.*\)/, '').trim())
@@ -243,7 +244,7 @@ function QuestionsDiagram() {
   var checkIfQuestionsMatchWithAnswersAndSyncWithHubspot = (question) => {
     let errors = []
     if (Object.values(model.layers[1].models).length > 0) {
-      var hbField = availableFields.find(a => a.name === question.options.extras.questionidentifier)
+      var selectedHbField = hbField.find(a => a.name === question.options.extras.questionidentifier)
       var As = Object.values(model.layers[1].models).filter(m => m.options.extras.customType === "answer")
       const answers = As.filter(a => {
         return Object.values(a.ports.In.links)[0] && Object.keys(question.ports.Out.links).includes(Object.values(a.ports.In.links)[0].options.id)
@@ -256,7 +257,7 @@ function QuestionsDiagram() {
         if (answer.options.extras.freeanswer) {
           answer.options.color = colorFreeanswer
         } else if (answer.options.extras.dropdown) {
-          const notExistingAnswers = checkDropDown(availableFields, answer)
+          const notExistingAnswers = checkDropDown(answer)
           if (notExistingAnswers.length == 0) {
             answer.options.color = colorDropdown
           } else {
@@ -264,7 +265,7 @@ function QuestionsDiagram() {
             errors.push(`'${notExistingAnswers.join(", ")}' doesnt exist on '${answer.options.name}'`)
           }
         } else {
-          const notExistingAnswers = hbField.options.filter(field => field.value.toLowerCase() == answer.options.extras.answeridentifier.toLowerCase())
+          const notExistingAnswers = selectedHbField.options.filter(field => field.value.toLowerCase() == answer.options.extras.answeridentifier.toLowerCase())
           if (notExistingAnswers.length === 0 && answer.options.extras.freeanswer_type !== "hidden") {
             answer.options.color = colorError
             question.options.color = colorError
@@ -455,8 +456,8 @@ function QuestionsDiagram() {
                 }} data-type="questiontranslation" data-color={questioncolor} style={{ borderColor: { questioncolor }, borderStyle: "solid" }} id="addquestiontranslation" required />
             </div>
             <div className="col-md-4">
-              <div className='d-flex align-items-end'>
-                <div className="w-100">
+              <div className='d-flex align-items-end flex-wrap'>
+                <div className="flex-grow-1">
                   <label htmlFor="addquestionidentifier">Questionidentifier</label>
                   <input className="form-control" name="questionidentifier" type="text" value={form['questionidentifier']}
                     onChange={(e) => {
@@ -464,6 +465,20 @@ function QuestionsDiagram() {
                       setForm({ ...form, [e.target.name]: e.target.value })
                     }} data-type="questionidentifier" data-color={questioncolor} style={{ borderColor: { questioncolor }, borderStyle: "solid" }} id="addquestionidentifier" required />
                 </div>
+                <select
+                  id="type"
+                  className={`custom-select w-auto mr-2`}
+                  value={form['questionidentifier']}
+                  onChange={e => {
+                    const matchingSubHbFields = hbFields.find(f => f.name === e.target.value)
+                    setForm({ ...form, questionidentifier: matchingSubHbFields.name })
+                    sethbFieldsAnswers(matchingSubHbFields.options)
+                  }}>
+                  <option disabled>select type</option>
+                  {(hbFields ? hbFields : []).map((f, i) => (
+                    <option key={i} value={f.name}>{f.name}</option>
+                  ))}
+                </select>
                 <button className="btn btn-primary ml-1" type="submit">{button}</button>
               </div>
             </div>
@@ -509,6 +524,18 @@ function QuestionsDiagram() {
                   <option disabled>select type</option>
                   {["text", "email", "number", "tel", "textarea", "hidden"].map((f, i) => (
                     <option key={i} value={f}>{f}</option>
+                  ))}
+                </select>
+                <select
+                  id="type"
+                  className={`custom-select w-auto mr-2`}
+                  value={form['answeridentifier']}
+                  onChange={e => {
+                    setForm({ ...form, answeridentifier: e.target.selectedOptions[0].value, dropdown: false, freeanswer: true })
+                  }}>
+                  <option disabled>select type</option>
+                  {(hbFieldsAnswers ? hbFieldsAnswers : []).map((f, i) => (
+                    <option key={i} value={f.value}>{f.value}</option>
                   ))}
                 </select>
                 <button className="btn btn-primary ml-1" type="submit">{button}</button>

--- a/assets/scripts/flow-builder.js
+++ b/assets/scripts/flow-builder.js
@@ -151,30 +151,29 @@ const render = (questions, flow) => {
 			const freeanswers = answers.filter(answer => answer.extras.freeanswer && !answer.extras.dropdown);
 			const dropdowns = answers.filter(answer => answer.extras.dropdown);
 			const attributes = (answer) => `
-placeholder="${isGerman ? (answer.extras.answertranslation.indexOf(':') !== -1 ? answer.extras.answertranslation.split(':')[1] : "") : (answer.name.indexOf(':') !== -1 ? answer.name.split(':')[1] : "")}"
-				placeholder="${isGerman ? (answer.extras.answertranslation.indexOf(':') !== -1 ? answer.extras.answertranslation.split(':')[1] : "") : (answer.name.indexOf(':') !== -1 ? answer.name.split(':')[1] : "")}" 
-placeholder="${isGerman ? (answer.extras.answertranslation.indexOf(':') !== -1 ? answer.extras.answertranslation.split(':')[1] : "") : (answer.name.indexOf(':') !== -1 ? answer.name.split(':')[1] : "")}"
+				placeholder="${isGerman ? (answer.extras.answertranslation.indexOf(':') !== -1 ? answer.extras.answertranslation.split(':')[1] : "") : (answer.name.indexOf(':') !== -1 ? answer.name.split(':')[1] : "")}"
 				class="form-control mb-4 freeanswer dynamicinput" 
-				name="${answer.extras.answeridentifier}" 
-				data-type="question" 
-				${answer.extras.freeanswer_type === 'hidden' ? `value="${answer.extras.freeanswer_type === 'hidden' ? `true` : answer.extras.answeridentifier}"` : ``}
+				name="${answer.extras.answeridentifier}"
+				data-type="question"
+				${answer.extras.freeanswer_type === 'hidden' ? `value="${answer.name}"` : ``}
 				type="${answer.extras.freeanswer_type ? answer.extras.freeanswer_type : "text"}" 
 				id="freeanswer_${answer.extras.answeridentifier}"
 				required`
 
 			const notTextAreas = freeanswers.filter(f => f.extras.freeanswer_type !== 'textarea' && f.extras.freeanswer_type !== 'hidden')
-			const textAreas = freeanswers.filter(f => f.extras.freeanswer_type === 'textarea')
+			const textAreas = freeanswers.filter(f => f.extras.freeanswer_type === 'textarea' && f.extras.freeanswer_type !== 'hidden')
+			const hiddens = freeanswers.filter(f => f.extras.freeanswer_type === 'hidden')
 			return `
-            <div class="d-flex justify-content-center mb-5 px-3">
-              <p class="text-center">${isGerman && question.extras.questiontranslation ? question.extras.questiontranslation : question.name}</p>
-            </div>
-            <div class="">
-              <div class="w-100">
-              ${freeanswers.length > 0 ? "<div class='row'>" + [...notTextAreas, ...textAreas].map((answer, index) => {
-				  return `<div class="
-				  ${((index === notTextAreas.length - 1) && (index % 2 == 0)) || answer.extras.freeanswer_type === 'textarea' ? 'col-12' : 'col-6'}">
-				  ${answer.extras.freeanswer_type !== 'hidden' ? `<label for="freeanswer_${answer.extras.answeridentifier}">
-				  ${isGerman ? (answer.extras.answertranslation.indexOf(':') !== -1 ? answer.extras.answertranslation.split(':')[0] : answer.extras.answertranslation) : (answer.name.indexOf(':') !== -1 ? answer.name.split(':')[0] : answer.name)}</label>` : ``}
+				<div class="d-flex justify-content-center mb-5 px-3">
+				<p class="text-center">${isGerman && question.extras.questiontranslation ? question.extras.questiontranslation : question.name}</p>
+				</div>
+				<div class="">
+				<div class="w-100">
+				${freeanswers.length > 0 ? "<div class='row'>" + [...notTextAreas, ...textAreas].map((answer, index) => {
+					return `<div class="
+					${((index === notTextAreas.length - 1) && (index % 2 == 0)) || answer.extras.freeanswer_type === 'textarea' ? 'col-12' : 'col-6'}">
+					${answer.extras.freeanswer_type !== 'hidden' ? `<label for="freeanswer_${answer.extras.answeridentifier}">
+					${isGerman ? (answer.extras.answertranslation.indexOf(':') !== -1 ? answer.extras.answertranslation.split(':')[0] : answer.extras.answertranslation) : (answer.name.indexOf(':') !== -1 ? answer.name.split(':')[0] : answer.name)}</label>` : ``}
 				  ${answer.extras.freeanswer_type === 'textarea' ? `
 					<textarea ${attributes(answer)} ></textarea>
 						` : `
@@ -182,7 +181,9 @@ placeholder="${isGerman ? (answer.extras.answertranslation.indexOf(':') !== -1 ?
 							`}
 
 				</div>`
-			  }).join('') + "</div><span id='error-msg' class='text-danger'></span>" : ""}
+				}).join('') + `${hiddens.map((answer, index) => {
+					return `<input ${attributes(answer)} />`
+				}).join('')}` + "</div><span id='error-msg' class='text-danger'></span>" : ""}
               ${dropdowns.length > 0 ? dropdowns.map(answer => (`
 			  <label for="dropdown_${answer.extras.answeridentifier}">${isGerman && answer.extras.answertranslation ? answer.extras.answertranslation.split(":")[0] : answer.name.split(":")[0]}</label>
 			  <select 

--- a/controllers/IndexController.js
+++ b/controllers/IndexController.js
@@ -284,6 +284,14 @@ module.exports.contact = async (req, res, next) => {
         filteredOptions.splice(filteredOptions.findIndex(i => i.property === missingP.name), 1)
       }))
       console.log(`### Try a second HS request without invalid properties: ${JSON.stringify(e.error.validationResults.map(i => i.name))}`)
+      const errorMailOptions = {
+        from: 'admin@digitalcareerinstitute.org',
+        to: settings.adminreceiver.split(','),
+        subject: 'Broken fields in Hubspot-request',
+        text: `Broken fields ${JSON.stringify(e.error.validationResults.map(i => i.name))}`,
+        html: `Broken fields ${JSON.stringify(e.error.validationResults.map(i => i.name))}`,
+      }
+      const info = sendMail(res, req, errorMailOptions)
       options.body.properties = filteredOptions
       const hubspotPromise2 = await requestPromise(options)
       console.log('### Result of 2nd hubspotPromise', hubspotPromise2);

--- a/controllers/IndexController.js
+++ b/controllers/IndexController.js
@@ -200,12 +200,7 @@ module.exports.contact = async (req, res, next) => {
     if (!!process.env.HUBSPOT_API_KEY) {
       let fbclid = getFbClid(req, res, next);
       properties = [
-        { property: 'firstname', value: firstname },
-        { property: 'lastname', value: lastname },
-        { property: 'email', value: email },
-        { property: 'phone', value: phone },
         { property: 'hs_facebook_click_id', value: fbclid },
-        { property: 'last_touchpoint', value: signup_form ? 'website_lead_form' : 'website_contact_form' },
         {
           property: 'form_payload',
           value: JSON.stringify({
@@ -220,19 +215,15 @@ module.exports.contact = async (req, res, next) => {
       ];
       const filteredPayload = Object.keys(req.body).reduce((acc, v) => {
         if (![
+          "age_field",
           "nb-confirmation-token",
           "nb-result",
           "nb-transaction-token",
           "termsofservice",
-          "email",
-          "firstname",
-          "lastname",
           "sendaltemail",
-          "phone",
           "track",
-          "body",
-          "age_field",
           "locations",
+          "body",
         ].map(i => i.toLowerCase()).includes(v.toLowerCase())) {
           acc[v] = req.body[v]
         }

--- a/models/setting.js
+++ b/models/setting.js
@@ -11,6 +11,7 @@ var SettingSchema = new Schema({
   announcement_banner_cta: String,
   tourmailreceiver: String,
   mailreceiver: String,
+  adminreceiver: String,
   show_language_markers: Boolean,
   careersuccesspage_alumni: Number,  
   careersuccesspage_students: Number,  


### PR DESCRIPTION
Backend
- if first HS request fails, filter broken fields and send second HS request without that fields
- possibility to define a [Setting](https://staging.digitalcareerinstitute.org/admin/settings) `adminmailreceiver` that receives internally debugging emails
- send a admin email with the broken fields to notify about missing properties

Frontend
- typo-free selection of HS `questions` and matching `answer`
- make eg. `last_touchpoint` as a free field and not depending on the old hardcoded form-flow